### PR TITLE
Feature 44 isintime

### DIFF
--- a/lib/plugins/in-timespan-plugin.js
+++ b/lib/plugins/in-timespan-plugin.js
@@ -1,0 +1,18 @@
+const utils = require('../utils')
+
+/**
+ * Return 1.0 if start <= time <= end, 0.0 otherwise.
+ * @param time - time to be checked
+ * @param start - begin of the timespan
+ * @param end - end of the timespan
+ */
+function inTimespanPlugin (time, start, end) {
+  if (end < start) {
+    let tmp = start
+    start = end
+    end = tmp
+  }
+  return utils.isInRange(time, start, end) ? 1.0 : 0.0
+}
+
+module.exports = inTimespanPlugin

--- a/lib/score-manager.js
+++ b/lib/score-manager.js
@@ -68,7 +68,14 @@ function ensureValidConfiguration (config) {
   ensureValidPlugins(config.plugins)
 }
 
-/** */
+/**
+ * Take an array of elements which are either scalar values or arrays and
+ * return a square array of arrays where all sub arrays have the same
+ * dimension broadcasting scalar values. For example:
+ *   [1, [2, 3], [4, 5]] -> [[1, 1], [2, 3], [4, 5]].
+ *
+ * @param inputValues - an array of elements that are scalar or arrays
+ */
 function expandValues (inputValues) {
   let length = inputValues.reduce((minLength, element) => {
     return Array.isArray(element)

--- a/lib/score-manager.js
+++ b/lib/score-manager.js
@@ -48,8 +48,8 @@ function ensureValidPlugins (plugins) {
     if (!plugin.inputs) {
       throw new InvalidInputError(`Plugin's input paths are missing: ${key}`)
     }
-    if (!Array.isArray(plugin.inputs) || plugin.inputs.length !== 2) {
-      throw new InvalidInputError(`Plugin's inputs field is not an array of length 2: ${key}`)
+    if (!Array.isArray(plugin.inputs)) {
+      throw new InvalidInputError(`Plugin's inputs field is not an array: ${key}`)
     }
   })
 }
@@ -66,6 +66,24 @@ function ensureValidConfiguration (config) {
   }
   ensureValidAggregator(config.aggregator)
   ensureValidPlugins(config.plugins)
+}
+
+/** */
+function expandValues (inputValues) {
+  let length = inputValues.reduce((minLength, element) => {
+    return Array.isArray(element)
+      ? Math.min(minLength, element.length) : minLength
+  }, Number.POSITIVE_INFINITY)
+
+  if (!Number.isFinite(length)) {
+    length = 1
+  }
+
+  let result = []
+  for (let i = 0; i < length; i++) {
+    result[i] = inputValues.map((element) => Array.isArray(element) ? element[i] : element)
+  }
+  return result
 }
 
 /**
@@ -208,8 +226,8 @@ class ScoreManager {
 
     let plugin = this.plugins[pluginId]
     try {
-      // inputs: [arg0, arg1]
-      let [arg0, arg1] = plugin.inputs.map(i => {
+      // Extract input values from blob by parsing path plugin.inputs.
+      let inputValues = plugin.inputs.map(i => {
         // Get pipes
         let pipes = pipeParser.getPipes(i)
         // Remove pipes from input
@@ -222,9 +240,12 @@ class ScoreManager {
         return value
       })
       let scoringFnc = getScoringFunction(plugin)
-      let scores = arg1.map(arg1 => {
+
+      let args = expandValues(inputValues)
+
+      let scores = args.map(arglist => {
         try {
-          return scoringFnc(arg0, arg1, plugin.params)
+          return scoringFnc.apply(null, arglist.concat([plugin.params]))
         } catch (err) {
           return 'failure: ' + err.message
         }

--- a/test/plugins/in-timespan-plugin-test.js
+++ b/test/plugins/in-timespan-plugin-test.js
@@ -1,0 +1,25 @@
+const buster = require('buster')
+const plugin = require('../../lib/plugins/in-timespan-plugin')
+
+buster.testCase('inTimespanPlugin', {
+  'should return 0.0 if time is not between start and end': function () {
+    let time = 0
+    let start = 10
+    let end = 20
+    buster.assert.same(plugin(time, start, end), 0.0)
+  },
+
+  'should return 1.0 if time is between start and end': function () {
+    let time = 15
+    let start = 10
+    let end = 20
+    buster.assert.same(plugin(time, start, end), 1.0)
+  },
+
+  'should return 1.0 if time is between start and end and end is less than start': function () {
+    let time = 15
+    let start = 20
+    let end = 10
+    buster.assert.same(plugin(time, start, end), 1.0)
+  }
+})

--- a/test/score-manager-test.js
+++ b/test/score-manager-test.js
@@ -391,6 +391,27 @@ buster.testCase('ScoreManager Integration', {
       let result = manager.score(blob)
       buster.assert.near(result[0]['in-time'], 1.0, 1e-3)
       buster.assert.near(result[1]['in-time'], 0.0, 1e-3)
+    },
+
+    'should return a length 1 array result when no array[] path is given': function () {
+      let config = {
+        aggregator: {'max': '*'},
+        plugins: {
+          'in-time': {
+            use: 'in-timespan-plugin',
+            inputs: ['file.created_at', 'file.other_date', 'file.due_date']
+          }
+        }
+      }
+      let manager = scoreManager.create(config)
+
+      let blob = {
+        file: { created_at: 1481924134, other_date: 1481924000, due_date: 1481924500 }
+      }
+
+      let result = manager.score(blob)
+      buster.assert.equals(result.length, 1)
+      buster.assert.near(result[0]['in-time'], 1.0, 1e-3)
     }
   },
 

--- a/test/score-manager-test.js
+++ b/test/score-manager-test.js
@@ -367,6 +367,33 @@ buster.testCase('ScoreManager Integration', {
     }
   },
 
+  'plugins with more than 2 arguments': {
+    'should receive arguments given in inputs array': function () {
+      let config = {
+        aggregator: {'max': '*'},
+        plugins: {
+          'in-time': {
+            use: 'in-timespan-plugin',
+            inputs: ['file.created_at', 'tasks[].created_at', 'tasks[].due_date']
+          }
+        }
+      }
+      let manager = scoreManager.create(config)
+
+      let blob = {
+        file: { created_at: 1481924134 },
+        tasks: [
+          { created_at: 1481924000, due_date: 1481924500 }, // yes case
+          { created_at: 1481920000, due_date: 1481924000 }  // no case
+        ]
+      }
+
+      let result = manager.score(blob)
+      buster.assert.near(result[0]['in-time'], 1.0, 1e-3)
+      buster.assert.near(result[1]['in-time'], 0.0, 1e-3)
+    }
+  },
+
   'plugin parameters': {
     'should be passed as third argument': function () {
       let pluginA = this.stub().returns(0.0)


### PR DESCRIPTION
Plugins can now take an arbitrary number of arguments, i.e.
```javascript
'in-time': {
  'use': 'in-timespan-plugin',
  inputs: ['file.created_at', 'tasks[].created_at', 'tasks[].due_date']
}
```
and `in-timespan-plugin` implemented.
