### PR TITLE
Feature 82 exceptions per plugin

### DIFF
--- a/lib/extract-object.js
+++ b/lib/extract-object.js
@@ -1,4 +1,5 @@
-const InvalidInputError = require('./invalid-input-error')
+// const InvalidInputError = require('./invalid-input-error')
+// const utils = require('./utils')
 
 /**
  * Return [ head, tail ] of path. A path is a dot '.' separated list of names,
@@ -12,16 +13,47 @@ function splitPath (path) {
   return p < 0 ? [path, ''] : [path.substring(0, p), path.substring(p + 1)]
 }
 
-/**
- * Throw an error if the object obj has no property named key.
- *
- * @param obj - the object to be tested
- * @param key - the key to be tested for
- */
-function ensurePropertyExists (obj, key) {
-  if (!obj.hasOwnProperty(key)) {
-    throw new InvalidInputError(`No such property: ${key}`)
-  }
+// /**
+//  * Throw an error if the object obj has no property named key.
+//  *
+//  * @param obj - the object to be tested
+//  * @param key - the key to be tested for
+//  */
+// function ensurePropertyExists (obj, key) {
+//   if (!obj.hasOwnProperty(key)) {
+//     throw new InvalidInputError(`No such property: ${key}`)
+//   }
+// }
+
+/** */
+function makeMultipleArraysError (path) {
+  let err = new Error(`more than one array specifier found '${path}'`)
+  err.name = 'MultipleArrays'
+  return err
+}
+
+/** */
+function makePropertyError (key) {
+  let err = new Error(`no such property '${key}'`)
+  err.name = 'NoSuchProperty'
+  err.property = key
+  return err
+}
+
+/** */
+function makeUnexpectedArrayError (key) {
+  let err = new Error(`unexpected array found: '${key}'`)
+  err.name = 'UnexpectedArray'
+  err.property = key
+  return err
+}
+
+/** */
+function makeArrayExpectedError (key) {
+  let err = new Error(`array expected but not found: '${key}'`)
+  err.name = 'ArrayExpected'
+  err.property = key
+  return err
 }
 
 /**
@@ -32,16 +64,16 @@ function ensurePropertyExists (obj, key) {
  * @param key - the key to be tested on obj
  * @param expected - true if an array is expected, false if array is unexpected
  */
-function ensureArrayIfExpected (obj, key, expected) {
-  let property = obj[key]
-  if (expected && !Array.isArray(property)) {
-    throw new InvalidInputError(`Array expected: ${key}`)
-  }
+// function ensureArrayIfExpected (obj, key, expected) {
+//   let property = obj[key]
+//   if (expected && !Array.isArray(property)) {
+//     throw new InvalidInputError(`Array expected: ${key}`)
+//   }
 
-  if (!expected && Array.isArray(property)) {
-    throw new InvalidInputError(`Unexpected array: ${key}`)
-  }
-}
+//   if (!expected && Array.isArray(property)) {
+//     throw new InvalidInputError(`Unexpected array: ${key}`)
+//   }
+// }
 
 /**
  * Throws an error if the path specification contains more than one pair of
@@ -49,12 +81,8 @@ function ensureArrayIfExpected (obj, key, expected) {
  *
  * @param path - the path to be checked, a dot separated list of names
  */
-function ensureZeroOrOneArray (path) {
-  let count = (path.match(/\[]/g) || []).length
-
-  if (count > 1) {
-    throw new InvalidInputError(`Multiple arrays in path found: ${path}`)
-  }
+function hasMoreThanOneArray (path) {
+  return (path.match(/\[]/g) || []).length > 1
 }
 
 /**
@@ -80,29 +108,55 @@ function ensureZeroOrOneArray (path) {
  * @param path - the path of the subobject to be extracted
  */
 function extractObject (obj, path) {
-  ensureZeroOrOneArray(path)
+  if (hasMoreThanOneArray(path)) {
+    return [undefined, makeMultipleArraysError(path)]
+  }
+
+  let errorlist = []
+  // TODO: return null sentinel instead of throwing on error.
+  // let expectArrayNext = false
   while (path !== '') {
     let [ key, rest ] = splitPath(path)
+    // console.log(`${key} - ${rest}: `)
+    // console.log(utils.toDebugString(obj))
     let expectArray = key.endsWith('[]')
     if (expectArray) {
       key = key.substring(0, key.length - 2)
     }
 
     if (Array.isArray(obj)) {
-      obj = obj.map(element => {
-        ensurePropertyExists(element, key)
+      // Traverse the path along all array elements.
+      obj = obj.map((element, index) => {
+        if (typeof element === 'undefined') {
+          return undefined
+        }
+        if (!element.hasOwnProperty(key)) {
+          errorlist[index] = makePropertyError(key)
+          return undefined
+        }
         return element[key]
       })
     } else {
-      ensurePropertyExists(obj, key)
-      ensureArrayIfExpected(obj, key, expectArray)
+      // ensureArrayIfExpected(obj, key, expectArray)
+      if (!obj.hasOwnProperty(key)) {
+        return [undefined, makePropertyError(key)]
+      }
+
+      if (expectArray && !Array.isArray(obj[key])) {
+        return [undefined, makeArrayExpectedError(key)]
+      }
+      // if there are more path segments to be parsed
+      if (!expectArray && Array.isArray(obj[key]) && rest.length > 0) {
+        return [undefined, makeUnexpectedArrayError(key)]
+      }
 
       obj = obj[key]
     }
 
+    // expectArrayNext = expectArray
     path = rest
   }
-  return obj
+  return [obj, errorlist.length === 0 ? null : errorlist]
 }
 
 module.exports = extractObject

--- a/lib/extract-object.js
+++ b/lib/extract-object.js
@@ -1,6 +1,3 @@
-// const InvalidInputError = require('./invalid-input-error')
-// const utils = require('./utils')
-
 /**
  * Return [ head, tail ] of path. A path is a dot '.' separated list of names,
  * for example: path.to.mydata. In this case the head is 'path' and the tail is
@@ -13,26 +10,24 @@ function splitPath (path) {
   return p < 0 ? [path, ''] : [path.substring(0, p), path.substring(p + 1)]
 }
 
-// /**
-//  * Throw an error if the object obj has no property named key.
-//  *
-//  * @param obj - the object to be tested
-//  * @param key - the key to be tested for
-//  */
-// function ensurePropertyExists (obj, key) {
-//   if (!obj.hasOwnProperty(key)) {
-//     throw new InvalidInputError(`No such property: ${key}`)
-//   }
-// }
-
-/** */
+/**
+ * Return an Error object with name property set to 'MultipleArrays' that
+ * represents an invalid path that has multiple array specifier in it, for
+ * example 'x[].y[]'.
+ * @param path - the path string that caused the error
+ */
 function makeMultipleArraysError (path) {
   let err = new Error(`more than one array specifier found '${path}'`)
   err.name = 'MultipleArrays'
   return err
 }
 
-/** */
+/**
+ * Return an Error object with name property set to 'NoSuchProperty' that
+ * represents an invalid request where a property with the specified path was
+ * not found in the object given to extractObject.
+ * @param key - the property key name that was not found
+ */
 function makePropertyError (key) {
   let err = new Error(`no such property '${key}'`)
   err.name = 'NoSuchProperty'
@@ -40,7 +35,12 @@ function makePropertyError (key) {
   return err
 }
 
-/** */
+/**
+ * Return an Error object with name property set to 'UnexpectedArray' that
+ * represents an invalid request where an array was found in the object given
+ * to extractObject but not specified in the path to be extracted.
+ * @param key - the property key name that unexpectedly was an array
+ */
 function makeUnexpectedArrayError (key) {
   let err = new Error(`unexpected array found: '${key}'`)
   err.name = 'UnexpectedArray'
@@ -48,32 +48,18 @@ function makeUnexpectedArrayError (key) {
   return err
 }
 
-/** */
+/**
+ * Return an Error object with name property set to 'ArrayExpected' that
+ * represents an invalid request where an array was specified in the path but
+ * no array was found in the object given to extractObject.
+ * @param key - the property key name that was expected to be an object
+ */
 function makeArrayExpectedError (key) {
   let err = new Error(`array expected but not found: '${key}'`)
   err.name = 'ArrayExpected'
   err.property = key
   return err
 }
-
-/**
- * Throw an error if property obj.key is an array but was not expected or if
- * the property obj.key is not an array but was expected.
- *
- * @param obj - the object to be tested
- * @param key - the key to be tested on obj
- * @param expected - true if an array is expected, false if array is unexpected
- */
-// function ensureArrayIfExpected (obj, key, expected) {
-//   let property = obj[key]
-//   if (expected && !Array.isArray(property)) {
-//     throw new InvalidInputError(`Array expected: ${key}`)
-//   }
-
-//   if (!expected && Array.isArray(property)) {
-//     throw new InvalidInputError(`Unexpected array: ${key}`)
-//   }
-// }
 
 /**
  * Throws an error if the path specification contains more than one pair of
@@ -86,12 +72,36 @@ function hasMoreThanOneArray (path) {
 }
 
 /**
+ * Return an array of the same dimensions as obj and replace each element e
+ * of obj with e[key]. If e[key] does not exist for an element return undefined
+ * for that element and set errorlist[index] with an Error object where index
+ * is the index of e in obj.
+ * @param obj - the array to traverse
+ * @param key - find property key of obj's elements
+ * @param errorlist - update errorlist if key was not found for some elements
+ */
+function traverseArray (obj, key, errorlist) {
+  // Traverse the path along all array elements.
+  obj = obj.map((element, index) => {
+    if (typeof element === 'undefined') {
+      return undefined
+    }
+    if (!element.hasOwnProperty(key)) {
+      errorlist[index] = makePropertyError(key)
+      return undefined
+    }
+    return element[key]
+  })
+  return [obj, errorlist]
+}
+
+/**
  * Extract part of the object obj defined by path.
  *
  * A valid path is a string where each property name is separated by the
  * containing object by a dot '.', for example 'foo.bar.baz' will refer to the
  * property value of 'baz' contained inside the object 'bar' which is in turn
- * saved as a property in 'foo'. Thus, the return value of the call
+ * saved as a property in 'foo'. Thus, the result of the call
  *   extractObject({ foo: { bar: { baz: 'Hello' } } }, 'foo.bar.baz')
  * will be the string 'Hello'.
  *
@@ -102,7 +112,20 @@ function hasMoreThanOneArray (path) {
  *   let obj = { a: [{ b: 'x' }, { b: 'y' }, { b: 'z' }] }
  *   let path = 'a[].b'
  *   // This assertion will pass.
- *   assert(extractObject(obj, path) === ['x', 'y', 'z'])
+ *   assert(extractObject(obj, path) === [['x', 'y', 'z'], []])
+ *
+ * The return value will be a two element array [result, error]. There are two
+ * cases:
+ *   1) the path contains an array specifier '[]',
+ *   2) the path contains no array specifier or the error occured before
+ *      parsing the array part of the object.
+ *
+ * In the first case, error is a list of errors that occured where the index is
+ * the index of the array element that could not be extracted and the value is
+ * an Error object describing the error condition. If no error occured the
+ * second elment of extractObject's return value will be an empty array.
+ * In the second case, error is either an Error object or null if no error
+ * occured.
  *
  * @param obj - the object whose subobject will be extracted
  * @param path - the path of the subobject to be extracted
@@ -113,29 +136,15 @@ function extractObject (obj, path) {
   }
 
   let errorlist = []
-  // TODO: return null sentinel instead of throwing on error.
-  // let expectArrayNext = false
   while (path !== '') {
     let [ key, rest ] = splitPath(path)
-    // console.log(`${key} - ${rest}: `)
-    // console.log(utils.toDebugString(obj))
     let expectArray = key.endsWith('[]')
     if (expectArray) {
       key = key.substring(0, key.length - 2)
     }
 
     if (Array.isArray(obj)) {
-      // Traverse the path along all array elements.
-      obj = obj.map((element, index) => {
-        if (typeof element === 'undefined') {
-          return undefined
-        }
-        if (!element.hasOwnProperty(key)) {
-          errorlist[index] = makePropertyError(key)
-          return undefined
-        }
-        return element[key]
-      })
+      [obj, errorlist] = traverseArray(obj, key, errorlist)
     } else {
       // ensureArrayIfExpected(obj, key, expectArray)
       if (!obj.hasOwnProperty(key)) {
@@ -153,7 +162,6 @@ function extractObject (obj, path) {
       obj = obj[key]
     }
 
-    // expectArrayNext = expectArray
     path = rest
   }
   return [obj, errorlist.length === 0 ? null : errorlist]

--- a/lib/score-manager.js
+++ b/lib/score-manager.js
@@ -105,6 +105,24 @@ function getScoringFunction (plugin) {
     ? utils.loadPlugin(plugin.use) : plugin.use
 }
 
+/** */
+function extractInputs (blob, inputPath) {
+  // Get pipes
+  let pipes = pipeParser.getPipes(inputPath)
+  // Remove pipes from input
+  inputPath = pipeParser.removePipes(inputPath)
+  let [value, errorlist] = extractObject(blob, inputPath)
+  if (errorlist) {
+    return [value, errorlist]
+  }
+
+  // Apply pipes
+  for (let pipe of pipes) {
+    value = pipeParser.applyPipe(pipe, value)
+  }
+  return [value, errorlist]
+}
+
 /**
  * There are three important concepts that facilitate assigning a score to
  * tasks representing the degree to which they match an uploaded file and it's
@@ -207,32 +225,25 @@ class ScoreManager {
     ensurePluginExists(this.plugins, pluginId)
 
     let plugin = this.plugins[pluginId]
-    try {
-      // inputs: [arg0, arg1]
-      let [arg0, arg1] = plugin.inputs.map(i => {
-        // Get pipes
-        let pipes = pipeParser.getPipes(i)
-        // Remove pipes from input
-        i = pipeParser.removePipes(i)
-        let value = extractObject(blob, i)
-        // Apply pipes
-        for (let pipe of pipes) {
-          value = pipeParser.applyPipe(pipe, value)
-        }
-        return value
-      })
-      let scoringFnc = getScoringFunction(plugin)
-      let scores = arg1.map(arg1 => {
-        try {
-          return scoringFnc(arg0, arg1, plugin.params)
-        } catch (err) {
-          return 'failure: ' + err.message
-        }
-      })
-      return scores
-    } catch (err) {
-      return ['failure: input data does not match configuration: ' + err.message]
-    }
+    // inputs: [arg0, arg1]
+    let [arg0, arg1] = plugin.inputs.map(inputPath => extractInputs(blob, inputPath))
+    let scoringFnc = getScoringFunction(plugin)
+    let [a0, e0] = arg0
+    let [a1, e1] = arg1
+    let scores = a1.map((a1, index) => {
+      if (e0) {
+        return 'failure: ' + e0.message
+      }
+      if (e1 && e1[index]) {
+        return 'failure: ' + e1[index].message
+      }
+      try {
+        return scoringFnc(a0, a1, plugin.params)
+      } catch (err) {
+        return 'failure: ' + err.message
+      }
+    })
+    return scores
   }
 
   /**

--- a/lib/score-manager.js
+++ b/lib/score-manager.js
@@ -105,7 +105,20 @@ function getScoringFunction (plugin) {
     ? utils.loadPlugin(plugin.use) : plugin.use
 }
 
-/** */
+/**
+ * Return the subobject from blob specified by inputPath where inputPath may
+ * contain pipes to preprocess the subobject, for example:
+ *   let blob      = { x: { y: 'z' } }
+ *   let inputPath = 'x.y | to-upper-case'
+ *
+ *   extractInputs(blob, inputPath) -> ['Z', null]
+ * If there are errors extracting the subobject due to an invalid path or
+ * non-matching data the second return value will be set (see extractObject).
+ * The return value will be [subobject, error].
+ *
+ * @param blob - the data from which a subobject will be extracted
+ * @param inputPath - the path of the subobject to be extracted
+ */
 function extractInputs (blob, inputPath) {
   // Get pipes
   let pipes = pipeParser.getPipes(inputPath)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,20 @@ function cloneObject (obj) {
 }
 
 /**
+ * Returns a human readable string representation of a JSON serializable
+ * javascript object.
+ * @param obj - a JSON serializable object.
+ */
+function toDebugString (obj) {
+  return JSON.stringify(obj)
+    .replace(/"/g, '\'')
+    .replace(/'([^ -']*)':/g, '$1:')
+    .replace(/{/g, '{ ')
+    .replace(/}/g, ' }')
+    .replace(/[:,]/g, '$& ')
+}
+
+/**
  * Check if a given string is a valid string
  *
  * @param sString - the string that needs to be checked
@@ -92,4 +106,4 @@ function loadPlugin (pluginId) {
   return loadModule('plugins', pluginId)
 }
 
-module.exports = { cloneObject, isValidString, isInRange, isInteger, isTimestamp, loadPlugin, loadModule }
+module.exports = { cloneObject, toDebugString, isValidString, isInRange, isInteger, isTimestamp, loadPlugin, loadModule }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,7 +14,7 @@ function cloneObject (obj) {
 function toDebugString (obj) {
   return JSON.stringify(obj)
     .replace(/"/g, '\'')
-    .replace(/'([^ -']*)':/g, '$1:')
+    .replace(/'([^ '-]*)':/g, '$1:')
     .replace(/{/g, '{ ')
     .replace(/}/g, ' }')
     .replace(/[:,]/g, '$& ')

--- a/test/extract-object-test.js
+++ b/test/extract-object-test.js
@@ -4,26 +4,30 @@ const extractObject = require('../lib/extract-object')
 buster.testCase('extractObject', {
   'should return the whole object when path is empty': () => {
     let obj = 'content'
-    let res = extractObject(obj, '')
+    let [res, err] = extractObject(obj, '')
     buster.assert.equals(res, obj)
+    buster.refute(err)
   },
 
   'should return the subobject when path is single name': () => {
     let obj = { x: 'content' }
-    let res = extractObject(obj, 'x')
+    let [res, err] = extractObject(obj, 'x')
     buster.assert.equals(res, 'content')
+    buster.refute(err)
   },
 
   'should return the subobject specified by path with names separated by dot': () => {
     let obj = { x: 'content', y: { z: 'foo' } }
-    let res = extractObject(obj, 'y.z')
+    let [res, err] = extractObject(obj, 'y.z')
     buster.assert.equals(res, 'foo')
+    buster.refute(err)
   },
 
   'should return an array with each subobject when path has []': () => {
     let obj = { x: [ 'y', 'z' ] }
-    let res = extractObject(obj, 'x[]')
+    let [res, err] = extractObject(obj, 'x[]')
     buster.assert.equals(res, [ 'y', 'z' ])
+    buster.refute(err)
   },
 
   'should return an array with each element\'s subobject when path has [].sub': () => {
@@ -31,8 +35,9 @@ buster.testCase('extractObject', {
       { y: 'foo' },
       { y: 'bar' }
     ] }
-    let res = extractObject(obj, 'x[].y')
+    let [res, err] = extractObject(obj, 'x[].y')
     buster.assert.equals(res, [ 'foo', 'bar' ])
+    buster.refute(err)
   },
 
   'should work with a random realistic object': () => {
@@ -47,35 +52,76 @@ buster.testCase('extractObject', {
         { name: 'bar', meta: { chat: 'world' } }
       ]
     }
-    let chats = extractObject(obj, 'tasks[].meta.chat')
-    let fileName = extractObject(obj, 'file.name')
+    let [chats, e1] = extractObject(obj, 'tasks[].meta.chat')
+    let [fileName, e2] = extractObject(obj, 'file.name')
     buster.assert.equals(chats, [ 'hello', 'world' ])
     buster.assert.equals(fileName, 'foo.txt')
+    buster.refute(e1)
+    buster.refute(e2)
   },
 
-  'should throw an exception when property does not exist': () => {
-    buster.assert.exception(() => extractObject({}, 'foo'))
-  },
+  'error cases': {
+    // extractObject(blob, path) -> [result, error] if path is non-array
+    // extractObject(blob, path) -> [result, errorlist] if path is array
+    'should return single error message if path is non-array path and key does not exist': function () {
+      let blob = {}
+      let path = 'x'
+      let [result, error] = extractObject(blob, path)
+      buster.assert.same(result, undefined)
+      buster.assert.equals(error.name, 'NoSuchProperty')
+      buster.assert.equals(error.property, 'x')
+    },
 
-  'should throw an exception when array is excepted but not found': () => {
-    buster.assert.exception(() => extractObject({ foo: 'Hello' }, 'foo[]'))
-  },
+    'should return error list if path is array path and key does not exist in one of the elements': function () {
+      let blob = { x: [{ y: '1' }, { noty: '2' }, { y: '3' }] }
+      let path = 'x[].y'
+      let [result, error] = extractObject(blob, path)
+      buster.assert.equals(result, ['1', undefined, '3'])
+      buster.assert.equals(error[1].name, 'NoSuchProperty')
+      buster.assert.equals(error[1].property, 'y')
+    },
 
-  'should throw an exception when no array is excepted but was found': () => {
-    buster.assert.exception(() => extractObject({ foo: ['Hello', 'World'] }, 'foo'))
-  },
+    'should return error list if path is array path and key does not exist in one of the elements (2)': function () {
+      let blob = { x: [{ y: { z: '1' } }, { noty: '2' }, { y: { z: '3' } }] }
+      let path = 'x[].y.z'
+      let [result, error] = extractObject(blob, path)
+      buster.assert.equals(result, ['1', undefined, '3'])
+      buster.assert.equals(error[1].name, 'NoSuchProperty')
+      buster.assert.equals(error[1].property, 'y')
+    },
 
-  'should throw an exception when array property is expected but not found': () => {
-    buster.assert.exception(() => extractObject({ foo: ['Hello'] }, 'foo[].bar'))
-  },
+    'should return error if array is expected but not found': function () {
+      let blob = { x: 'x-value' }
+      let path = 'x[]'
+      let [result, error] = extractObject(blob, path)
+      buster.assert.same(result, undefined)
+      buster.assert.equals(error.name, 'ArrayExpected')
+      buster.assert.equals(error.property, 'x')
+    },
 
-  'should throw an exception when more than one array is defined in path': () => {
-    let obj = {
-      foo: [
-        { bar: [{ baz: 1 }, { baz: 2 }] },
-        { bar: [{ baz: 3 }, { baz: 4 }] }
-      ]
+    'should return error if array is found but not expected': function () {
+      let blob = { x: [{ y: 'x1' }, { y: 'x2' }] }
+      let path = 'x.y'
+      let [result, error] = extractObject(blob, path)
+      buster.assert.same(result, undefined)
+      buster.assert.equals(error.name, 'UnexpectedArray')
+      buster.assert.equals(error.property, 'x')
+    },
+
+    'should return error if more than one array is specified in path': function () {
+      let blob = {}
+      let path = 'x[].y[].z'
+      let [result, error] = extractObject(blob, path)
+      buster.assert.same(result, undefined)
+      buster.assert.equals(error.name, 'MultipleArrays')
     }
-    buster.assert.exception(() => extractObject(obj, 'foo[].bar[].baz'))
+  },
+
+  'should return array if it is the last thing in the path without [] specifier': function () {
+    let blob = { x: [ 'x1', 'x2' ] }
+    let path = 'x'
+    let [result, error] = extractObject(blob, path)
+    buster.assert.equals(result, [ 'x1', 'x2' ])
+    buster.refute(error)
   }
 })

--- a/test/score-manager-test.js
+++ b/test/score-manager-test.js
@@ -244,7 +244,7 @@ buster.testCase('ScoreManager with configuration', {
       buster.assert.match(result[0]['plugin-c'], /this is the error description/)
     },
 
-    'should be caught and isolated on a per plugin bases': function () {
+    'should be caught and isolated on a per plugin basis': function () {
       let aggregator = { combine: this.stub().returns(1.0) }
       let plugA = () => 1.0
       let plugB = () => 1.0
@@ -264,6 +264,27 @@ buster.testCase('ScoreManager with configuration', {
 
       let result = manager.score(blob)
       buster.assert.match(result[0]['plugin-a'], /no-attribute-here/)
+    },
+
+    'should be caught and isolated on a per task basis': function () {
+      let aggregator = { combine: this.stub().returns(1.0) }
+      let plugA = () => 1.0
+
+      let manager = scoreManager.create({
+        aggregator,
+        plugins: {
+          'plugin-a': { use: plugA, inputs: ['file', 'tasks[].description'] }
+        }
+      })
+
+      let blob = {
+        file: {},
+        tasks: [{ description: 'this is a task' }, { x: 'no description here' }]
+      }
+
+      let result = manager.score(blob)
+      buster.assert.same(result[0]['plugin-a'], 1.0)
+      buster.assert.match(result[1]['plugin-a'], /failure/)
     },
 
     'should only pass successful scores to the aggregator': function () {

--- a/test/utils-test.js
+++ b/test/utils-test.js
@@ -1,0 +1,12 @@
+const utils = require('../lib/utils')
+const buster = require('buster')
+
+buster.testCase('utils', {
+  'toDebugString': {
+    'should return a human readable string of a javascript object': function () {
+      let obj = { x: '134', y: 123, 'this-is-z': null }
+      let str = utils.toDebugString(obj)
+      buster.assert.equals(str, '{ x: \'134\', y: 123, \'this-is-z\': null }')
+    }
+  }
+})


### PR DESCRIPTION
Failure to find property in input path in one array element for a plugin only affects that array element. For example given:
```javascript
let config =  { ..., 
  plugins: { 
    'plug-a-desc': { use: 'plug-a', inputs: ['a.desc', 'b[].desc'] } 
  }
}
let blob = { a: { desc: '123' }, b: [ { desc: '456' }, {}, { desc: '789' } ] }
```
only `b[1]` will fail, while `b[0]` and `b[2]` will correctly passed to `plug-a`.