### PR TITLE
Feature 12 chat text comparison

### DIFF
--- a/lib/plugins/chat-text-plugin.js
+++ b/lib/plugins/chat-text-plugin.js
@@ -21,7 +21,7 @@ function chatComparisonPlugin (chat, text) {
   for (let message of messageText) {
     singleMessageScores.push(similarityPlugin(message, text))
   }
-  console.log('Single scores: ' + singleMessageScores)
+  // console.log('Single scores: ' + singleMessageScores)
   return mean.eval(singleMessageScores)
 }
 

--- a/lib/plugins/chat-text-plugin.js
+++ b/lib/plugins/chat-text-plugin.js
@@ -13,13 +13,17 @@ const utils = require('../utils.js')
  */
 function chatComparisonPlugin (chat, text) {
   let [messageText, e1] = extractObject(chat, 'chat[].text')
-  if (e1 !== null) {
+  if ((e1 !== null) && (e1.constructor === Error)) {
     throw new Error('Error extracting text from chat.')
   }
+
+  utils.arrayNotEmpty(messageText)
   utils.isValidString(text)
   var singleMessageScores = []
   for (let message of messageText) {
-    singleMessageScores.push(similarityPlugin(message, text))
+    if ((message !== undefined) && (typeof (message) === 'string')) {
+      singleMessageScores.push(similarityPlugin(message, text))
+    }
   }
 
   return meanAggregator.create('*').eval(singleMessageScores)

--- a/lib/plugins/chat-text-plugin.js
+++ b/lib/plugins/chat-text-plugin.js
@@ -1,6 +1,7 @@
 const extractObject = require('../extract-object.js')
 const similarityPlugin = require('./similar-text-plugin.js')
 const meanAggregator = require('../aggregators/mean.js')
+const utils = require('../utils.js')
 
 var mean = meanAggregator.create('*')
 /**
@@ -18,6 +19,7 @@ function chatComparisonPlugin (chat, text) {
     }
   }
   var singleMessageScores = []
+  utils.isValidString(text)
   for (let message of messageText) {
     singleMessageScores.push(similarityPlugin(message, text))
   }

--- a/lib/plugins/chat-text-plugin.js
+++ b/lib/plugins/chat-text-plugin.js
@@ -3,28 +3,26 @@ const similarityPlugin = require('./similar-text-plugin.js')
 const meanAggregator = require('../aggregators/mean.js')
 const utils = require('../utils.js')
 
-var mean = meanAggregator.create('*')
 /**
  * Takes as an input an object of the form:
  *
  * @param chat - an object that is a chat
  * @param text - an object that is a text
- * @return score - between 1.0 and 0.0
+ * @return score - between 1.0 and 0.0. This is the mean value of all the
+ * similarities between every single chat message and text.
  */
 function chatComparisonPlugin (chat, text) {
   let [messageText, e1] = extractObject(chat, 'chat[].text')
   if (e1 !== null) {
-    for (let e of e1) {
-      throw e
-    }
+    throw new Error('Error extracting text from chat.')
   }
-  var singleMessageScores = []
   utils.isValidString(text)
+  var singleMessageScores = []
   for (let message of messageText) {
     singleMessageScores.push(similarityPlugin(message, text))
   }
-  // console.log('Single scores: ' + singleMessageScores)
-  return mean.eval(singleMessageScores)
+
+  return meanAggregator.create('*').eval(singleMessageScores)
 }
 
 module.exports = chatComparisonPlugin

--- a/lib/plugins/chat-text-plugin.js
+++ b/lib/plugins/chat-text-plugin.js
@@ -1,0 +1,28 @@
+const extractObject = require('../extract-object.js')
+const similarityPlugin = require('./similar-text-plugin.js')
+const meanAggregator = require('../aggregators/mean.js')
+
+var mean = meanAggregator.create('*')
+/**
+ * Takes as an input an object of the form:
+ *
+ * @param chat - an object that is a chat
+ * @param text - an object that is a text
+ * @return score - between 1.0 and 0.0
+ */
+function chatComparisonPlugin (chat, text) {
+  let [messageText, e1] = extractObject(chat, 'chat[].text')
+  if (e1 !== null) {
+    for (let e of e1) {
+      throw e
+    }
+  }
+  var singleMessageScores = []
+  for (let message of messageText) {
+    singleMessageScores.push(similarityPlugin(message, text))
+  }
+  console.log('Single scores: ' + singleMessageScores)
+  return mean.eval(singleMessageScores)
+}
+
+module.exports = chatComparisonPlugin

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -177,4 +177,20 @@ function ensureValidAggregators (aggregators) {
   })
 }
 
-module.exports = { cloneObject, toDebugString, isValidString, isArray, isInRange, isInteger, isTimestamp, loadPlugin, loadModule, insertByPath, ensureValidAggregators }
+/**
+ * Throw an error if array is empty.
+ * @param array - the array to be checked
+ */
+function arrayNotEmpty (array) {
+  let count = 0
+  for (let a of array) {
+    if (a === undefined) {
+      count++
+    }
+  }
+  if (count === array.length) {
+    throw new Error('Array empty.')
+  }
+}
+
+module.exports = { cloneObject, toDebugString, isValidString, isArray, isInRange, isInteger, isTimestamp, loadPlugin, loadModule, insertByPath, ensureValidAggregators, arrayNotEmpty }

--- a/test/plugins/chat-text-plugin-test.js
+++ b/test/plugins/chat-text-plugin-test.js
@@ -5,17 +5,11 @@ const testChat = {
   chat: [
     {
       'type': 'message',
-      'channel': 'C2147483705',
-      'user': 'U2147483697',
-      'text': 'Hello world',
-      'ts': 1355517523.000005
+      'text': 'Hello world'
     },
     {
       'type': 'message',
-      'channel': 'C2147483705',
-      'user': 'U2147483698',
-      'text': 'Hello underworld',
-      'ts': 1355517545.000005
+      'text': 'Hello underworld'
     }
   ]
 }
@@ -24,20 +18,74 @@ const testChatSimple = {
   chat: [
     {
       'type': 'message',
-      'channel': 'C2147483705',
-      'user': 'U2147483697',
-      'text': 'Hello world',
-      'ts': 1355517523.000005
+      'text': 'Hello world'
     }
   ]
 }
 
+const brokenChat = {
+  chat: [
+    {
+      'type': 'message',
+      'notext': 1234
+    },
+    {
+      'type': 'message',
+      'notext': 'Hello underworld'
+    }
+  ]
+}
+
+const halfChat = {
+  chat: [
+    {
+      'type': 'message',
+      'notext': 1234
+    },
+    {
+      'type': 'message',
+      'text': 'Hello'
+    }
+  ]
+}
+
+const wrongeTypeChat = {
+  chat: [
+    {
+      'type': 'message',
+      'notext': 1234
+    },
+    {
+      'type': 'message',
+      'text': 'Hello'
+    }
+  ]
+}
+
+const extractObjectBroken = {
+  chat: 'chat value'
+}
+
 buster.testCase('Chat Scorer', {
-  'should throw error if no text in chat': function () {
+  'should throw error if chat': function () {
     buster.assert.exception(() => plugin('', 'testphrase'))
   },
   'should throw error if no text to compare to': function () {
     buster.assert.exception(() => plugin(testChat, ''))
+  },
+  'should throw error if no text in chat messages': function () {
+    buster.assert.exception(() => plugin(brokenChat, 'testphrase'))
+  },
+  'should throw error if chat messages cannot be extracted': function () {
+    buster.assert.exception(() => plugin(extractObjectBroken, 'Hello'))
+  },
+  'should ignore chat messages without text if others do have text': function () {
+    let result = plugin(halfChat, 'Hello')
+    buster.assert.equals(result, 1.0)
+  },
+  'should ignore chat messages without text': function () {
+    let result = plugin(wrongeTypeChat, 'Hello')
+    buster.assert.equals(result, 1.0)
   },
   'should throw error if second arg is not a valid string': function () {
     buster.assert.exception(() => plugin(testChat, 1))

--- a/test/plugins/chat-text-plugin-test.js
+++ b/test/plugins/chat-text-plugin-test.js
@@ -39,6 +39,9 @@ buster.testCase('Chat Scorer', {
   'should throw error if no text to compare to': function () {
     buster.assert.exception(() => plugin(testChat, ''))
   },
+  'should throw error if second arg is not a valid string': function () {
+    buster.assert.exception(() => plugin(testChat, 1))
+  },
   'should score 1 if chatmessage matches text': function () {
     let compareText = testChatSimple.chat[0].text
     let result = plugin(testChatSimple, compareText)

--- a/test/plugins/chat-text-plugin-test.js
+++ b/test/plugins/chat-text-plugin-test.js
@@ -1,0 +1,57 @@
+const buster = require('buster')
+const plugin = require('../../lib/plugins/chat-text-plugin.js')
+
+const testChat = {
+  chat: [
+    {
+      'type': 'message',
+      'channel': 'C2147483705',
+      'user': 'U2147483697',
+      'text': 'Hello world',
+      'ts': 1355517523.000005
+    },
+    {
+      'type': 'message',
+      'channel': 'C2147483705',
+      'user': 'U2147483698',
+      'text': 'Hello underworld',
+      'ts': 1355517545.000005
+    }
+  ]
+}
+
+const testChatSimple = {
+  chat: [
+    {
+      'type': 'message',
+      'channel': 'C2147483705',
+      'user': 'U2147483697',
+      'text': 'Hello world',
+      'ts': 1355517523.000005
+    }
+  ]
+}
+
+buster.testCase('Chat Scorer', {
+  'should throw error if no text in chat': function () {
+    buster.assert.exception(() => plugin('', 'testphrase'))
+  },
+  'should throw error if no text to compare to': function () {
+    buster.assert.exception(() => plugin(testChat, ''))
+  },
+  'should score 1 if chatmessage matches text': function () {
+    let compareText = testChatSimple.chat[0].text
+    let result = plugin(testChatSimple, compareText)
+    buster.assert.equals(result, 1.0)
+  },
+  'should score high if high similarity between messages and text': function () {
+    let compareText = 'Hello world'
+    let result = plugin(testChat, compareText)
+    buster.assert.near(result, 1.0, 0.3)
+  },
+  'should score low if low similarity between messages and text': function () {
+    let compareText = 'underwater'
+    let result = plugin(testChat, compareText)
+    buster.assert.near(result, 0.0, 0.3)
+  }
+})

--- a/test/plugins/chat-text-plugin-test.js
+++ b/test/plugins/chat-text-plugin-test.js
@@ -49,9 +49,14 @@ buster.testCase('Chat Scorer', {
     let result = plugin(testChat, compareText)
     buster.assert.near(result, 1.0, 0.3)
   },
-  'should score low if low similarity between messages and text': function () {
-    let compareText = 'underwater'
+  'should score medium if medium similarity between messages and text': function () {
+    let compareText = 'Hello'
     let result = plugin(testChat, compareText)
-    buster.assert.near(result, 0.0, 0.3)
+    buster.assert.near(result, 0.5, 0.3)
+  },
+  'should score low if low similarity between messages and text': function () {
+    let compareText = 'water'
+    let result = plugin(testChat, compareText)
+    buster.assert.near(result, 0.0, 0.2)
   }
 })


### PR DESCRIPTION
Added chat-text-plugin.
Messages from a Chat (Spec see [rest-api reference](https://github.com/amos-ws16/amos-ws16-arrowjs/blob/master/docs/rest-api.md)) can be compared to a text, e.g. task.title oder task.description.
No filtering for keywords up to now. 